### PR TITLE
Keri 2: Cross-platform Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@
 */bourbon/
 # Ignore any HTML files
 slides_built/
+# Ignore any archive files
+slides_archive/
 

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ $(ARCHIVE_DIR)/%$(ARCHIVE_FILE_EXT): $(BUILD_DIR)/%$(HTML_DIR_EXT)/
 	@echo "    Archiving "$^" into "$@
 	@cd $(BUILD_DIR); zip --quiet -r ../$@ $(*F)$(HTML_DIR_EXT)/
 
+.PRECIOUS: $(BUILD_DIR)/%$(HTML_DIR_EXT)/  # Do NOT remove these intermediate files
 $(BUILD_DIR)/%$(HTML_DIR_EXT)/: $(RAW_DIR)/%$(RAW_FILE_EXT)
 	@echo "    Building "$@" from "$^
 	$(CALL_MAKE) bourbon_install

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@
 # 3. Open slides_built/<YOUR_PRESENTATION>_html/index.html in a web browser
 # 4. Distrubute slides_archive/<YOUR_PRESENTATION>.zip as you see fit
 #
+# Global "constants" are defined in Makefile_constants
 # Source: https://github.com/hark130/keen-risk
 #
 
@@ -15,51 +16,15 @@
 ### MAKEFILE VARIABLES ###
 ##########################
 
-### OS-DYNAMIC VARIABLES ###
-# $(CHECK) - Checkmark
-CHECK :=
+### OS-DEPENDENT INCLUSION ###
 ifeq ($(OS),Windows_NT)
 include Makefile_windows
 else
-# This section assumes Linux
 include Makefile_linux
 endif
 
 .PHONY: all compile clean validate
 
-### HOVERCRAFT ARGUMENTS ###
-HC_ARGS = --slide-numbers
-
-### MAKEFILE ARGUMENTS ###
-MF_ARGS = --no-print-directory
-CALL_MAKE = @$(MAKE) $(MF_ARGS)
-
-### DIRECTORIES ###
-# Relative path to the directory holding the rst source files
-RAW_DIR = slides_raw
-# Relative path to the directory to store the "compiled" HTML files
-BUILD_DIR = slides_built
-# Relative path to the directory to store the zip-formatted HTML archives
-ARCHIVE_DIR = slides_archive
-
-### FILE EXTENSIONS ###
-RAW_FILE_EXT = .rst
-HTML_DIR_EXT = _html
-ARCHIVE_FILE_EXT = .zip
-
-### DYNAMIC VARIABLES ###
-# All .rst filenames found in RAW_DIR
-# RAW_FILENAMES:=$(shell cd $(RAW_DIR); $(LSD) *$(RAW_FILE_EXT))
-# RAW_FILENAMES = 00_00-EXAMPLES.rst 00_01-TEMPLATE.rst 
-# All RAW_FILENAMES with the file extension stripped
-# PRESENTATIONS := $(basename $(RAW_FILENAMES))
-# Relative directory names for the per-presentation BUILD_DIR directories
-# HTML_DIRS := $(addprefix $(BUILD_DIR)$(SEP),$(addsuffix $(HTML_DIR_EXT),$(PRESENTATIONS)))
-# Relative filenames for the pre-presentation archive files
-# ARCHIVE_FILES := $(addprefix $(ARCHIVE_DIR)$(SEP),$(addsuffix $(ARCHIVE_FILE_EXT),$(PRESENTATIONS)))
-# FILES := $(foreach DIR,$(RAW_DIR),$(wildcard $(DIR)\*))
-
-ARCHIVE_DIR_WIN := $(ARCHIVE_DIR)*
 
 ##########################
 ##### MAKEFILE RULES #####

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ ARCHIVE_FILE_EXT = .zip
 ### DYNAMIC VARIABLES ###
 # RST_FILES = $(addprefix $(RAW_DIR)/,$(addsuffix $(RAW_FILE_EXT),$(PRESENTATIONS)))
 ARCHIVE_FILES = $(addprefix $(ARCHIVE_DIR)/,$(addsuffix $(ARCHIVE_FILE_EXT),$(PRESENTATIONS)))
+HTML_DIRS = $(addprefix $(BUILD_DIR)/,$(addsuffix $(HTML_DIR_EXT),$(PRESENTATIONS)))
 
 ### OS-DYNAMIC VARIABLES ###
 # Where to shunt output to silence it?
@@ -48,9 +49,7 @@ all:
 .PHONY: all
 
 bourbon_install:
-	@cd $(RAW_DIR)
-	@BOURBON_RESULTS="$(shell bourbon install)"  # Silence bourbon results
-	@cd ..
+	@BOURBON_RESULTS="$(shell cd $(RAW_DIR); bourbon install)"  # Silence bourbon results
 
 compile:
 	@echo
@@ -71,7 +70,7 @@ clean_archive:
 
 clean_build:
 	@echo "    Cleaning "$(BUILD_DIR)" directory"
-	@echo "        TO DO: DON'T DO NOW... implement clean_build, agnostic of host OS"
+	@$(foreach HTML_DIR, $(HTML_DIRS), $(RM) -r $(HTML_DIR))
 
 validate:
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,19 @@
 ##########################
+###### INSTRUCTIONS ######
+##########################
+#
+# 1. Save <YOUR_PRESENTATION>.rst file into the slides_raw directory
+# 2. make
+# 3. Open slides_built/<YOUR_PRESENTATION>_html/index.html in a web browser
+# 4. Distrubute slides_archive/<YOUR_PRESENTATION>.zip as you see fit
+#
+# Source: https://github.com/hark130/keen-risk
+#
+
+
+##########################
 ### MAKEFILE VARIABLES ###
 ##########################
-
-### INSTRUCTOR PRESENTATIONS ###
-# Update this variable with the base filename (no file extension) whenever you add a new
-# presentation source file to the RAW_DIR.
-PRESENTATIONS = \
-	00_00-EXAMPLES \
-	00_01-TEMPLATE
 
 ### HOVERCRAFT ARGUMENTS ###
 HC_ARGS = --slide-numbers
@@ -29,18 +35,26 @@ RAW_FILE_EXT = .rst
 HTML_DIR_EXT = _html
 ARCHIVE_FILE_EXT = .zip
 
-### DYNAMIC VARIABLES ###
-# RST_FILES = $(addprefix $(RAW_DIR)/,$(addsuffix $(RAW_FILE_EXT),$(PRESENTATIONS)))
-ARCHIVE_FILES = $(addprefix $(ARCHIVE_DIR)/,$(addsuffix $(ARCHIVE_FILE_EXT),$(PRESENTATIONS)))
-HTML_DIRS = $(addprefix $(BUILD_DIR)/,$(addsuffix $(HTML_DIR_EXT),$(PRESENTATIONS)))
-
 ### OS-DYNAMIC VARIABLES ###
 # Where to shunt output to silence it?
 NULL = /dev/null
+# What is the command to list directory contents?
+LSD = ls
 
-######################
-### MAKEFILE RULES ###
-######################
+### DYNAMIC VARIABLES ###
+# All .rst filenames found in RAW_DIR
+RAW_FILENAMES=$(shell cd $(RAW_DIR); $(LSD) *$(RAW_FILE_EXT))
+# All RAW_FILENAMES with the file extension stripped
+PRESENTATIONS=$(basename $(RAW_FILENAMES))
+# Relative directory names for the per-presentation BUILD_DIR directories
+HTML_DIRS = $(addprefix $(BUILD_DIR)/,$(addsuffix $(HTML_DIR_EXT),$(PRESENTATIONS)))
+# Relative filenames for the pre-presentation archive files
+ARCHIVE_FILES = $(addprefix $(ARCHIVE_DIR)/,$(addsuffix $(ARCHIVE_FILE_EXT),$(PRESENTATIONS)))
+
+
+##########################
+##### MAKEFILE RULES #####
+##########################
 all:
 	$(CALL_MAKE) validate
 	$(CALL_MAKE) clean

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ validate_hovercraft:
 
 $(ARCHIVE_DIR)/%$(ARCHIVE_FILE_EXT): $(BUILD_DIR)/%$(HTML_DIR_EXT)/
 	@echo "    Archiving "$^" into "$@
+	@cd $(BUILD_DIR); zip --quiet -r ../$@ $(*F)$(HTML_DIR_EXT)/
 
 $(BUILD_DIR)/%$(HTML_DIR_EXT)/: $(RAW_DIR)/%$(RAW_FILE_EXT)
 	@echo "    Building "$@" from "$^

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,99 @@
+##########################
+### MAKEFILE VARIABLES ###
+##########################
+
+### INSTRUCTOR PRESENTATIONS ###
+# Update this variable with the base filename (no file extension) whenever you add a new
+# presentation source file to the RAW_DIR.
+PRESENTATIONS = \
+	00_00-EXAMPLES \
+	00_01-TEMPLATE
+
+### HOVERCRAFT ARGUMENTS ###
+HC_ARGS = --slide-numbers
+
+### MAKEFILE ARGUMENTS ###
+MF_ARGS = --no-print-directory
+CALL_MAKE = @$(MAKE) $(MF_ARGS)
+
+### DIRECTORIES ###
+# Relative path to the directory holding the rst source files
+RAW_DIR = slides_raw
+# Relative path to the directory to store the "compiled" HTML files
+BUILD_DIR = slides_built
+# Relative path to the directory to store the zip-formatted HTML archives
+ARCHIVE_DIR = slides_archive
+
+### FILE EXTENSIONS ###
+RAW_FILE_EXT = .rst
+HTML_DIR_EXT = _html
+ARCHIVE_FILE_EXT = .zip
+
+### DYNAMIC VARIABLES ###
+# RST_FILES = $(addprefix $(RAW_DIR)/,$(addsuffix $(RAW_FILE_EXT),$(PRESENTATIONS)))
+ARCHIVE_FILES = $(addprefix $(ARCHIVE_DIR)/,$(addsuffix $(ARCHIVE_FILE_EXT),$(PRESENTATIONS)))
+
+### OS-DYNAMIC VARIABLES ###
+# Where to shunt output to silence it?
+NULL = /dev/null
+
+######################
+### MAKEFILE RULES ###
+######################
+all:
+	$(CALL_MAKE) validate
+	$(CALL_MAKE) clean
+	$(CALL_MAKE) compile
+
+.PHONY: all
+
+bourbon_install:
+	@cd $(RAW_DIR)
+	@BOURBON_RESULTS="$(shell bourbon install)"  # Silence bourbon results
+	@cd ..
+
+compile:
+	@echo
+	@echo "COMPILING"
+	$(CALL_MAKE) _compile
+
+_compile: $(foreach ARCHIVE_FILE, $(ARCHIVE_FILES), $(ARCHIVE_FILE))
+
+clean:
+	@echo
+	@echo "CLEANING"
+	$(CALL_MAKE) clean_build
+	$(CALL_MAKE) clean_archive
+
+clean_archive:
+	@echo "    Cleaning "$(ARCHIVE_DIR)" directory"
+	@$(foreach ARCHIVE_FILE, $(ARCHIVE_FILES), $(RM) $(ARCHIVE_FILE))
+
+clean_build:
+	@echo "    Cleaning "$(BUILD_DIR)" directory"
+	@echo "        TO DO: DON'T DO NOW... implement clean_build, agnostic of host OS"
+
+validate:
+	@echo
+	@echo "VALIDATING"
+	$(CALL_MAKE) validate_bourbon
+	$(CALL_MAKE) validate_hovercraft
+
+validate_bourbon:
+	@echo "    Validating bourbon"
+	@bourbon --version > $(NULL)  # Tests the command before printing the version
+	@BOURBON_VERSION="$(shell bourbon --version)"; echo "        [✓] "$$BOURBON_VERSION
+
+validate_hovercraft:
+	@echo "    Validating hovercraft"
+	@hovercraft --version > $(NULL)  # Tests the command before printing the version
+	@HOVERCRAFT_VERSION="$(shell hovercraft --version)"; echo "        [✓] "$$HOVERCRAFT_VERSION
+
+$(ARCHIVE_DIR)/%$(ARCHIVE_FILE_EXT): $(BUILD_DIR)/%$(HTML_DIR_EXT)/
+	@echo "    Archiving "$^" into "$@
+
+$(BUILD_DIR)/%$(HTML_DIR_EXT)/: $(RAW_DIR)/%$(RAW_FILE_EXT)
+	@echo "    Building "$@" from "$^
+	$(CALL_MAKE) bourbon_install
+	@mkdir $@
+	@hovercraft $(HC_ARGS) $^ $@

--- a/Makefile_constants
+++ b/Makefile_constants
@@ -1,0 +1,33 @@
+##########################
+###### INSTRUCTIONS ######
+##########################
+#
+# 1. Stop reading this
+# 2. Read Makefile instead
+# 3. Take care to avoid circular inclusion and redundancies
+#
+
+
+##########################
+### MAKEFILE VARIABLES ###
+##########################
+
+### DIRECTORIES ###
+# Relative path to the directory holding the rst source files
+RAW_DIR = slides_raw
+# Relative path to the directory to store the "compiled" HTML files
+BUILD_DIR = slides_built
+# Relative path to the directory to store the zip-formatted HTML archives
+ARCHIVE_DIR = slides_archive
+
+### FILE EXTENSIONS ###
+RAW_FILE_EXT = .rst
+HTML_DIR_EXT = _html
+ARCHIVE_FILE_EXT = .zip
+
+### HOVERCRAFT ARGUMENTS ###
+HC_ARGS = --slide-numbers
+
+### MAKEFILE ARGUMENTS ###
+MF_ARGS = --no-print-directory
+CALL_MAKE = @$(MAKE) $(MF_ARGS)

--- a/Makefile_linux
+++ b/Makefile_linux
@@ -64,6 +64,7 @@ _clean:
 	$(CALL_MAKE) _clean_archive
 
 _clean_archive:
+	@echo "    Cleaning "$(ARCHIVE_DIR)" directory"
 	@$(foreach ARCHIVE_FILE, $(ARCHIVE_FILES), rm --force $(ARCHIVE_DIR)/$(ARCHIVE_FILE);)
 
 _clean_build:
@@ -71,32 +72,33 @@ _clean_build:
 	@$(foreach HTML_DIR, $(HTML_DIRS), rm --recursive --force $(BUILD_DIR)/$(HTML_DIR))
 
 _validate:
-	$(CALL_MAKE) validate_bourbon
-	$(CALL_MAKE) validate_hovercraft
+	$(CALL_MAKE) _validate_bourbon
+	$(CALL_MAKE) _validate_hovercraft
 
 _validate_bourbon:
 	@echo "    Validating bourbon"
 	@bourbon --version > $(NULL)
-	@echo         $(CHECK) $(shell bourbon --version)
+	@echo "        $(CHECK) $(shell bourbon --version)"
 
 _validate_hovercraft:
 	@echo "    Validating hovercraft"
 	@hovercraft --version > $(NULL)
-	@echo         $(CHECK) $(shell hovercraft --version)
+	@echo "        $(CHECK) $(shell hovercraft --version)"
 
 %$(ARCHIVE_FILE_EXT): %$(HTML_DIR_EXT)
 	@echo "    Archiving $(BUILD_DIR)/$^ into $(ARCHIVE_DIR)/$@"
 	@cd $(BUILD_DIR); zip --quiet -r ../$(ARCHIVE_DIR)/$@ $^/
+	@echo ""
 
 .PRECIOUS: %$(HTML_DIR_EXT)
 
 %$(HTML_DIR_EXT): %$(RAW_FILE_EXT)
-	@echo "    Building $(BUILD_DIR)\$@ from $(RAW_DIR)\$^"
+	@echo "    Building $(BUILD_DIR)/$@ from $(RAW_DIR)/$^"
 	$(CALL_MAKE) --silent _bourbon_install
-	@mkdir $(BUILD_DIR)\$@
-	@echo "TO DO: DON'T DO NOW... test the creation of the $(BUILD_DIR)\$@ here"
-	@hovercraft $(HC_ARGS) $(RAW_DIR)\$^ $(BUILD_DIR)\$@
+	@mkdir $(BUILD_DIR)/$@
+	@if ! [ -d $(BUILD_DIR)/$@ ] ; then echo "Unable to locate the $(BUILD_DIR)/$@ directory" >&2 && exit 2 ; fi
+	@hovercraft $(HC_ARGS) $(RAW_DIR)/$^ $(BUILD_DIR)/$@
 
 %$(RAW_FILE_EXT):
-	@echo "    Verifying $(RAW_DIR)\$(@F)"
-	@echo "TO DO: DON'T DO NOW... check for the .rst file here"
+	@echo "    Verifying $(RAW_DIR)/$@"
+	@if ! [ -f $(RAW_DIR)/$@ ] ; then echo "Unable to locate the $(RAW_DIR)/$@ file" >&2 && exit 2 ; fi

--- a/Makefile_linux
+++ b/Makefile_linux
@@ -1,0 +1,102 @@
+##########################
+###### INSTRUCTIONS ######
+##########################
+#
+# 1. Stop reading this
+# 2. Read Makefile instead
+# 3. Thank Linus for this wonderful kernel!
+#
+
+
+##################################
+#### LINUX MAKEFILE VARIABLES ####
+##################################
+
+### CONSTANT VARIABLES ###
+# This was made to avoid circular dependencies and redundancies
+include Makefile_constants
+
+### OS-DYNAMIC VARIABLES ###
+# $(CHECK) - Checkmark
+CHECK :=
+ifneq ($(OS),Windows_NT)
+	CHECK = [✓]
+else
+$(error Wrong operating system.  This is $(OS).)
+endif
+
+# $(NULL) - Shunt output here to silence it
+NULL :=
+ifneq ($(OS),Windows_NT)
+	NULL = /dev/null
+else
+$(error Wrong operating system.  This is $(OS).)
+endif
+
+### DYNAMIC VARIABLES ###
+# All .rst filenames found in RAW_DIR
+RAW_FILENAMES := $(shell cd $(RAW_DIR); ls *$(RAW_FILE_EXT))
+# All RAW_FILENAMES with the file extension stripped
+PRESENTATIONS := $(basename $(RAW_FILENAMES))
+# Relative directory names for the per-presentation BUILD_DIR directories
+HTML_DIRS := $(addsuffix $(HTML_DIR_EXT),$(PRESENTATIONS))
+# Relative filenames for the pre-presentation archive files
+ARCHIVE_FILES := $(addsuffix $(ARCHIVE_FILE_EXT),$(PRESENTATIONS))
+
+
+##################################
+###### LINUX MAKEFILE RULES ######
+##################################
+_all:
+	$(CALL_MAKE) validate
+	$(CALL_MAKE) clean
+	$(CALL_MAKE) compile
+
+.PHONY: _all _bourbon_install _compile _clean _clean_archive _clean_build _validate _validate_bourbon _validate_hovercraft
+
+_bourbon_install:
+	@BOURBON_RESULTS="$(shell cd $(RAW_DIR); bourbon install)"  # Silence bourbon results
+
+_compile: $(foreach ARCHIVE_FILE, $(ARCHIVE_FILES), $(ARCHIVE_FILE))
+
+_clean:
+	$(CALL_MAKE) _clean_build
+	$(CALL_MAKE) _clean_archive
+
+_clean_archive:
+	@$(foreach ARCHIVE_FILE, $(ARCHIVE_FILES), rm --force $(ARCHIVE_DIR)/$(ARCHIVE_FILE);)
+
+_clean_build:
+	@echo "    Cleaning "$(BUILD_DIR)" directory"
+	@$(foreach HTML_DIR, $(HTML_DIRS), rm --recursive --force $(BUILD_DIR)/$(HTML_DIR))
+
+_validate:
+	$(CALL_MAKE) validate_bourbon
+	$(CALL_MAKE) validate_hovercraft
+
+_validate_bourbon:
+	@echo "    Validating bourbon"
+	@bourbon --version > $(NULL)
+	@echo         $(CHECK) $(shell bourbon --version)
+
+_validate_hovercraft:
+	@echo "    Validating hovercraft"
+	@hovercraft --version > $(NULL)
+	@echo         $(CHECK) $(shell hovercraft --version)
+
+%$(ARCHIVE_FILE_EXT): %$(HTML_DIR_EXT)
+	@echo "    Archiving $(BUILD_DIR)/$^ into $(ARCHIVE_DIR)/$@"
+	@cd $(BUILD_DIR); zip --quiet -r ../$(ARCHIVE_DIR)/$@ $^/
+
+.PRECIOUS: %$(HTML_DIR_EXT)
+
+%$(HTML_DIR_EXT): %$(RAW_FILE_EXT)
+	@echo "    Building $(BUILD_DIR)\$@ from $(RAW_DIR)\$^"
+	$(CALL_MAKE) --silent _bourbon_install
+	@mkdir $(BUILD_DIR)\$@
+	@echo "TO DO: DON'T DO NOW... test the creation of the $(BUILD_DIR)\$@ here"
+	@hovercraft $(HC_ARGS) $(RAW_DIR)\$^ $(BUILD_DIR)\$@
+
+%$(RAW_FILE_EXT):
+	@echo "    Verifying $(RAW_DIR)\$(@F)"
+	@echo "TO DO: DON'T DO NOW... check for the .rst file here"

--- a/Makefile_windows
+++ b/Makefile_windows
@@ -8,29 +8,13 @@
 #
 
 
-##########################
-### MAKEFILE VARIABLES ###
-##########################
+##################################
+### WINDOWS MAKEFILE VARIABLES ###
+##################################
 
-### HOVERCRAFT ARGUMENTS ###
-HC_ARGS = --slide-numbers
-
-### MAKEFILE ARGUMENTS ###
-MF_ARGS = --no-print-directory
-CALL_MAKE = @$(MAKE) $(MF_ARGS)
-
-### DIRECTORIES ###
-# Relative path to the directory holding the rst source files
-RAW_DIR = slides_raw
-# Relative path to the directory to store the "compiled" HTML files
-BUILD_DIR = slides_built
-# Relative path to the directory to store the zip-formatted HTML archives
-ARCHIVE_DIR = slides_archive
-
-### FILE EXTENSIONS ###
-RAW_FILE_EXT = .rst
-HTML_DIR_EXT = _html
-ARCHIVE_FILE_EXT = .zip
+### CONSTANT VARIABLES ###
+# This was made to avoid circular dependencies and redundancies
+include Makefile_constants
 
 ### OS-DYNAMIC VARIABLES ###
 # $(CHECK) - Checkmark
@@ -44,7 +28,7 @@ endif
 # $(NULL) - Shunt output here to silence it
 NULL :=
 ifeq ($(OS),Windows_NT)
-	# It is nul in cmd.exe but we're using Powershell now so it's NULL
+	# It is nul in cmd.exe but we're using Powershell now so it's $null
 	NULL = \$null
 else
 $(error Wrong operating system.  This is $(OS).)
@@ -62,23 +46,18 @@ endif
 
 ### DYNAMIC VARIABLES ###
 # All .rst filenames found in RAW_DIR
-# RAW_FILENAMES:=$(shell cd $(RAW_DIR); $(LSD) *$(RAW_FILE_EXT))
-RAW_FILENAMES = 00_00-EXAMPLES.rst 00_01-TEMPLATE.rst 
+RAW_FILENAMES := $(shell Get-ChildItem -Path .\slides_raw\\*$(RAW_FILE_EXT) -File -Name)
 # All RAW_FILENAMES with the file extension stripped
 PRESENTATIONS := $(basename $(RAW_FILENAMES))
 # Relative directory names for the per-presentation BUILD_DIR directories
-# HTML_DIRS := $(addprefix $(BUILD_DIR),$(addsuffix $(HTML_DIR_EXT),$(PRESENTATIONS)))
 HTML_DIRS := $(addsuffix $(HTML_DIR_EXT),$(PRESENTATIONS))
 # Relative filenames for the pre-presentation archive files
 ARCHIVE_FILES := $(addsuffix $(ARCHIVE_FILE_EXT),$(PRESENTATIONS))
-# ARCHIVE_FILES := $(addprefix $(ARCHIVE_DIR)\,$(addsuffix $(ARCHIVE_FILE_EXT),$(PRESENTATIONS)))
-# ARCHIVE_FILES := $(shell Join-Path -Path $(ARCHIVE_DIR) -ChildPath $path2)
-# FILES := $(foreach DIR,$(RAW_DIR),$(wildcard $(DIR)\*))
 
 
-##########################
-##### MAKEFILE RULES #####
-##########################
+##################################
+##### WINDOWS MAKEFILE RULES #####
+##################################
 _all:
 	$(CALL_MAKE) validate
 	$(CALL_MAKE) clean
@@ -110,11 +89,13 @@ _validate:
 
 _validate_bourbon:
 	@echo "    Validating bourbon"
+	@# This check will short-circuit the rule before printing anything
 	@bourbon --version > $(NULL)
 	@echo "        $(CHECK) $(shell bourbon --version)"
 
 _validate_hovercraft:
 	@echo "    Validating hovercraft"
+	@# This check will short-circuit the rule before printing anything
 	@hovercraft --version > $(NULL)
 	@echo "        $(CHECK) $(shell hovercraft --version)"
 

--- a/Makefile_windows
+++ b/Makefile_windows
@@ -1,0 +1,139 @@
+##########################
+###### INSTRUCTIONS ######
+##########################
+#
+# 1. Stop reading this
+# 2. Read Makefile instead
+# 3. Defenestrate Windows!
+#
+
+
+##########################
+### MAKEFILE VARIABLES ###
+##########################
+
+### HOVERCRAFT ARGUMENTS ###
+HC_ARGS = --slide-numbers
+
+### MAKEFILE ARGUMENTS ###
+MF_ARGS = --no-print-directory
+CALL_MAKE = @$(MAKE) $(MF_ARGS)
+
+### DIRECTORIES ###
+# Relative path to the directory holding the rst source files
+RAW_DIR = slides_raw
+# Relative path to the directory to store the "compiled" HTML files
+BUILD_DIR = slides_built
+# Relative path to the directory to store the zip-formatted HTML archives
+ARCHIVE_DIR = slides_archive
+
+### FILE EXTENSIONS ###
+RAW_FILE_EXT = .rst
+HTML_DIR_EXT = _html
+ARCHIVE_FILE_EXT = .zip
+
+### OS-DYNAMIC VARIABLES ###
+# $(CHECK) - Checkmark
+CHECK := 
+ifeq ($(OS),Windows_NT)
+	CHECK = [*]
+else
+$(error Wrong operating system.  This is $(OS).)
+endif
+
+# $(NULL) - Shunt output here to silence it
+NULL :=
+ifeq ($(OS),Windows_NT)
+	# It is nul in cmd.exe but we're using Powershell now so it's NULL
+	NULL = \$null
+else
+$(error Wrong operating system.  This is $(OS).)
+endif
+
+# $(SHELL) - OS-specific shell to execute commands in
+ifeq ($(OS),Windows_NT)
+	# Windows commands are wonky in GNU Make since it defaults to cmd.exe
+	# We're going to force powershell usage.
+	SHELL := powershell.exe
+	.SHELLFLAGS := -NoProfile -Command
+else
+$(error Wrong operating system.  This is $(OS).)
+endif
+
+### DYNAMIC VARIABLES ###
+# All .rst filenames found in RAW_DIR
+# RAW_FILENAMES:=$(shell cd $(RAW_DIR); $(LSD) *$(RAW_FILE_EXT))
+RAW_FILENAMES = 00_00-EXAMPLES.rst 00_01-TEMPLATE.rst 
+# All RAW_FILENAMES with the file extension stripped
+PRESENTATIONS := $(basename $(RAW_FILENAMES))
+# Relative directory names for the per-presentation BUILD_DIR directories
+# HTML_DIRS := $(addprefix $(BUILD_DIR),$(addsuffix $(HTML_DIR_EXT),$(PRESENTATIONS)))
+HTML_DIRS := $(addsuffix $(HTML_DIR_EXT),$(PRESENTATIONS))
+# Relative filenames for the pre-presentation archive files
+ARCHIVE_FILES := $(addsuffix $(ARCHIVE_FILE_EXT),$(PRESENTATIONS))
+# ARCHIVE_FILES := $(addprefix $(ARCHIVE_DIR)\,$(addsuffix $(ARCHIVE_FILE_EXT),$(PRESENTATIONS)))
+# ARCHIVE_FILES := $(shell Join-Path -Path $(ARCHIVE_DIR) -ChildPath $path2)
+# FILES := $(foreach DIR,$(RAW_DIR),$(wildcard $(DIR)\*))
+
+
+##########################
+##### MAKEFILE RULES #####
+##########################
+_all:
+	$(CALL_MAKE) validate
+	$(CALL_MAKE) clean
+	$(CALL_MAKE) compile
+
+.PHONY: _all _bourbon_install _compile _clean _clean_archive _clean_build _validate _validate_bourbon _validate_hovercraft
+
+_bourbon_install:
+	@$(shell cd $(RAW_DIR); bourbon install > $(NULL) 2>&1)
+
+_compile: $(foreach ARCHIVE_FILE, $(ARCHIVE_FILES), $(ARCHIVE_FILE))
+
+_clean:
+	$(CALL_MAKE) _clean_build
+	$(CALL_MAKE) _clean_archive
+
+_clean_archive:
+	@echo "    Cleaning $(ARCHIVE_DIR) directory"
+	@$(foreach ARCHIVE_FILE, $(ARCHIVE_FILES), if (Test-Path $(ARCHIVE_DIR)\$(ARCHIVE_FILE)) {Remove-Item $(ARCHIVE_DIR)\$(ARCHIVE_FILE) -Force -ErrorAction Ignore};)
+
+_clean_build:
+	@echo "    Cleaning $(BUILD_DIR) directory"
+	@$(foreach HTML_DIR, $(HTML_DIRS), Get-ChildItem -Path $(BUILD_DIR)\$(HTML_DIR) -Recurse | Remove-Item -force -recurse;)
+	@$(foreach HTML_DIR, $(HTML_DIRS), if (Test-Path -Path $(BUILD_DIR)\$(HTML_DIR)) {Remove-Item $(BUILD_DIR)\$(HTML_DIR) -Force -ErrorAction Ignore};)
+
+_validate:
+	$(CALL_MAKE) _validate_bourbon
+	$(CALL_MAKE) _validate_hovercraft
+
+_validate_bourbon:
+	@echo "    Validating bourbon"
+	@bourbon --version > $(NULL)
+	@echo "        $(CHECK) $(shell bourbon --version)"
+
+_validate_hovercraft:
+	@echo "    Validating hovercraft"
+	@hovercraft --version > $(NULL)
+	@echo "        $(CHECK) $(shell hovercraft --version)"
+
+%$(ARCHIVE_FILE_EXT): %$(HTML_DIR_EXT)
+	@echo "    Archiving $(BUILD_DIR)\$^ into $(ARCHIVE_DIR)\$@"
+	@$(shell Compress-Archive -Path $(BUILD_DIR)\$^ -DestinationPath $(ARCHIVE_DIR)\$@;)
+	@echo ""
+
+.PRECIOUS: %$(HTML_DIR_EXT)
+
+%$(HTML_DIR_EXT): %$(RAW_FILE_EXT)
+	@echo "    Building $(BUILD_DIR)\$@ from $(RAW_DIR)\$^"
+	$(CALL_MAKE) --silent _bourbon_install
+	@$(shell New-Item -Path "$(BUILD_DIR)\$@" -ItemType Directory > $(NULL) 2>&1)
+	@# Since the conditional is a Powershell command, the catalyst for failing the recipe must also be Powershell.
+	@if("$(shell Test-Path "$(BUILD_DIR)\$@" -PathType Container)" -ne "True"){Write-Error "Unable to locate $(BUILD_DIR)\$@."}
+	@hovercraft $(HC_ARGS) $(RAW_DIR)\$^ $(BUILD_DIR)\$@
+
+%$(RAW_FILE_EXT):
+	@echo "    Verifying $(RAW_DIR)\$(@F)"
+	@# Since the conditional is a Powershell command, the catalyst for failing the recipe must also be Powershell.
+	@if("$(shell Test-Path "$(RAW_DIR)\$@" -PathType Leaf)" -ne "True"){Write-Error "Unable to locate $(RAW_DIR)\$@."}

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ From the top-level repo directory:
 cd slides_raw
 bourbon install  # This only needs to be done once
 cd ..
-hovercraft --slide-numbers ./slides_raw/00_00-EXAMPLES.rst ./slides_built/
-firefox ./slides_built/index.html  # As one example of what to open and how to open it
+mkdir ./slides_built/00_00-EXAMPLES/
+hovercraft --slide-numbers ./slides_raw/00_00-EXAMPLES.rst ./slides_built/00_00-EXAMPLES/
+firefox ./slides_built/00_00-EXAMPLES/index.html  # As one example of what to open and how to open it
 ```

--- a/README.md
+++ b/README.md
@@ -46,7 +46,21 @@ See: Installation
 
 ### Scripted
 
-TO DO: DON'T DO NOW... see KERI-2
+This will validate dependencies, clean existing files/directories, and compile all `.rst` files found in the `slides_raw` directory.
+
+`make`
+
+(AKA `make all`)
+
+Each of the individual steps may be manually executed:
+
+```
+make validate  # Validates software dependencies: bourbon, hovercraft.
+make clean     # Deletes HTML directories from slides_build and all archive files from slides_archive.
+make compile   # Builds everything from scratch for all .rst files found in the slides_raw directory.
+```
+
+These Makefile recipes work in both Linux and Windows operating systems.
 
 ### Manual
 

--- a/README.md
+++ b/README.md
@@ -41,12 +41,14 @@ See: Installation
         * [Download](https://www.gnu.org/software/make/#download) and install manually
     * Windows
         * [Download](https://gnuwin32.sourceforge.net/packages/make.htm) and install manually
+        * Override the default installation directory to be `C:\GnuWin32`, or something similar, because Powershell doesn't like the `(x86)` directory name
+        * Add the absolute path to the `make.exe` file (`C:\GnuWin32\bin\` in this example) to the `PATH` environment variable so you can execute `make` commands
 
 ## Compile Slides
 
 ### Scripted
 
-This will validate dependencies, clean existing files/directories, and compile all `.rst` files found in the `slides_raw` directory.
+This will validate dependencies, clean existing files/directories, and compile all `.rst` files found in the `slides_raw` directory.  From the Makefile's local directory:
 
 `make`
 


### PR DESCRIPTION
New Makefile executes the OS-specific rules to:

- Verify dependencies
- Compile all .rst files
- Archive compiled slides into .zips

Makefile functionality tested on Ubuntu bash and Windows Powershell.

`README.md` updated with "scripted" instructions.
README Installation instructions updated with some Windows-on-GnuMake pitfalls.